### PR TITLE
Fix VSCodeIO read() not supporting multiple lines per chunk

### DIFF
--- a/src/vscode_io.ts
+++ b/src/vscode_io.ts
@@ -32,11 +32,9 @@ export function createVSCodeIO(
     _lines: readLines(reader),
 
     read: async function (): Promise<string | void> {
-      for await (const line of this._lines) {
-        return line;
-      }
-
-      return this._decoder.decode();
+      const line = await lines.next();
+      if (line.done) return decoder.decode();
+      return line.value;
     },
 
     write: async function (m: string): Promise<void> {

--- a/src/vscode_io.ts
+++ b/src/vscode_io.ts
@@ -32,8 +32,8 @@ export function createVSCodeIO(
     _lines: readLines(reader),
 
     read: async function (): Promise<string | void> {
-      const line = await lines.next();
-      if (line.done) return decoder.decode();
+      const line = await this._lines.next();
+      if (line.done) return this._decoder.decode();
       return line.value;
     },
 

--- a/src/vscode_io.ts
+++ b/src/vscode_io.ts
@@ -9,6 +9,7 @@ export interface VSCodeIO extends IO {
   _decoder: TextDecoder;
   _reader: Deno.Reader;
   _writer: Deno.Writer;
+  _lines: AsyncIterableIterator<string>;
   write(message: string): Promise<void>;
   read(): Promise<string | void>;
 }
@@ -28,9 +29,10 @@ export function createVSCodeIO(
     _encoder: new TextEncoder(),
     _reader: reader,
     _writer: writer,
+    _lines: readLines(reader),
 
     read: async function (): Promise<string | void> {
-      for await (const line of readLines(this._reader)) {
+      for await (const line of this._lines) {
         return line;
       }
 


### PR DESCRIPTION
The vscodeio read() function would run readLines() each time, which would make it only able to read the first line in the chunk, defeating the point of using readLines() entirely, this fixes it by making it actually read each line